### PR TITLE
Fix bug in path assembly

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,10 +49,9 @@ def main(src_path, dst_path, auto_yes=False):
     tr = LeftAligned(draw=BoxStyle(gfx=BOX_LIGHT, horiz_len=1))
     print(tr(tree))
 
-    # Prepend base path to dst_path
-    for file in files:
-        file["dst_path"] = os.path.join(src_path, file["dst_path"])
-        file["summary"] = summaries[files.index(file)]["summary"]
+    # Associate summaries with the proposed files
+    for idx, file in enumerate(files):
+        file["summary"] = summaries[idx]["summary"]
 
     if not auto_yes and not click.confirm(
         "Proceed with directory structure?", default=True


### PR DESCRIPTION
## Summary
- don't prepend src path when creating proposed file tree

## Testing
- `flake8 --max-line-length=120 main.py`
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fee6687d083218d1b25ef43effb11